### PR TITLE
Rewrite User class

### DIFF
--- a/src/RealTimeClient.php
+++ b/src/RealTimeClient.php
@@ -473,6 +473,16 @@ class RealTimeClient extends ApiClient
                     $bot = new Bot($this, $payload['bot']);
                     $this->bots[$bot->getId()] = $bot;
                     break;
+
+                case 'team_join':
+                    $user = new User($this, $payload['user']);
+                    $this->users[$user->getId()] = $user;
+                    break;
+
+                case 'user_change':
+                    $user = new User($this, $payload['user']);
+                    $this->users[$user->getId()] = $user;
+                    break;
             }
 
             // emit an event with the attached json

--- a/src/SlackUser.php
+++ b/src/SlackUser.php
@@ -1,0 +1,235 @@
+<?php
+namespace Slack;
+
+/**
+ * Contains information about a team member.
+ */
+abstract class SlackUser
+{
+    /**
+     * @var array
+     */
+    protected $data = [];
+
+    /**
+     * Gets the user's ID.
+     *
+     * @return string The user's ID.
+     */
+    public function getId()
+    {
+        return $this->data['id'];
+    }
+
+    /**
+     * Gets the user's username.
+     *
+     * Does not include the @ symbol at the beginning.
+     *
+     * @return string The user's username.
+     */
+    public function getUsername()
+    {
+        return $this->data['name'];
+    }
+
+    /**
+     * Gets the user's first name if supplied.
+     *
+     * @return string The user's first name, or null if no name was given.
+     */
+    public function getFirstName()
+    {
+        return isset($this->data['profile']['first_name']) ? $this->data['profile']['first_name'] : null;
+    }
+
+    /**
+     * Gets the user's last name if supplied.
+     *
+     * @return string The user's last name, or null if no name was given.
+     */
+    public function getLastName()
+    {
+        return isset($this->data['profile']['last_name']) ? $this->data['profile']['last_name'] : null;
+    }
+
+    /**
+     * Gets the user's real name if supplied.
+     *
+     * @return string The user's real name, or null if no name was given.
+     */
+    public function getRealName()
+    {
+        return isset($this->data['profile']['real_name']) ? $this->data['profile']['real_name'] : null;
+    }
+
+    /**
+     * Gets the user's email address if supplied.
+     *
+     * @return string The user's email address, or null if no email was given.
+     */
+    public function getEmail()
+    {
+        return isset($this->data['profile']['email']) ? $this->data['profile']['email'] : null;
+    }
+
+    /**
+     * Gets the user's phone number if supplied.
+     *
+     * @return string The user's phone number, or null if no number was given.
+     */
+    public function getPhone()
+    {
+        return isset($this->data['profile']['phone']) ? $this->data['profile']['phone'] : null;
+    }
+
+    /**
+     * Gets the user's Skype name if supplied.
+     *
+     * @return string The user's Skype name, or null if no Skype name was given.
+     */
+    public function getSkype()
+    {
+        return isset($this->data['profile']['skype']) ? $this->data['profile']['skype'] : null;
+    }
+
+    /**
+     * Checks if the user is a team administrator.
+     *
+     * @return bool True if the user is a team administrator.
+     */
+    public function isAdmin()
+    {
+        return $this->data['is_admin'];
+    }
+
+    /**
+     * Checks if the user is a team owner.
+     *
+     * @return bool True if the user is a team owner.
+     */
+    public function isOwner()
+    {
+        return $this->data['is_owner'];
+    }
+
+    /**
+     * Checks if the user is the team's primary owner.
+     *
+     * @return bool True if the user is the primary team owner.
+     */
+    public function isPrimaryOwner()
+    {
+        return $this->data['is_primary_owner'];
+    }
+
+    /**
+     * Checks if the user has been deactivated.
+     *
+     * @return bool True if the user is deactivated.
+     */
+    public function isDeleted()
+    {
+        return $this->data['deleted'];
+    }
+
+    /**
+     * Gets a user's presence.
+     *
+     * @return \React\Promise\PromiseInterface|null The current user's presence, either "active" or "away".
+     */
+    public function getPresence()
+    {
+        if ($this->client == null) {
+            return null;
+        }
+
+        return $this->client->apiCall('users.getPresence', [
+            'user' => $this->getId(),
+        ])->then(function (Payload $response) {
+            return $response['presence'];
+        });
+    }
+
+    /**
+     * User profile image URL 24x24px
+     *
+     * @return string URL of the 24x24px user profile image
+     */
+    public function getProfileImage24()
+    {
+        return $this->data['profile']['image_24'];
+    }
+
+    /**
+     * User profile image URL 32x32px
+     *
+     * @return string URL of the 32x32px user profile image
+     */
+    public function getProfileImage32()
+    {
+        return $this->data['profile']['image_32'];
+    }
+
+    /**
+     * User profile image URL 48x48px
+     *
+     * @return string URL of the 48x48px user profile image
+     */
+    public function getProfileImage48()
+    {
+        return $this->data['profile']['image_48'];
+    }
+
+    /**
+     * User profile image URL 72x72px
+     *
+     * @return string URL of the 72x72px user profile image
+     */
+    public function getProfileImage72()
+    {
+        return $this->data['profile']['image_72'];
+    }
+
+    /**
+     * User profile image URL 192x192px
+     *
+     * @return string URL of the 192x192px user profile image
+     */
+    public function getProfileImage192()
+    {
+        return $this->data['profile']['image_192'];
+    }
+
+    /**
+     * @return string user status text or null
+     */
+    public function getStatusText()
+    {
+        return isset($this->data['profile']['status_text']) ? $this->data['profile']['status_text'] : null;
+    }
+
+    /**
+     * @return string user status emoji or null
+     */
+    public function getStatusEmoji()
+    {
+        return isset($this->data['profile']['status_emoji']) ? $this->data['profile']['status_emoji'] : null;
+    }
+
+    /**
+     * @return string username color code
+     */
+    public function getColor()
+    {
+        return $this->data['color'];
+    }
+
+    /**
+     * @return integer timestamp when the user was last edited
+     */
+    public function getUpdated()
+    {
+        return $this->data['updated'];
+    }
+}

--- a/src/User.php
+++ b/src/User.php
@@ -4,191 +4,42 @@ namespace Slack;
 /**
  * Contains information about a team member.
  */
-class User extends ClientObject
+class User extends SlackUser
 {
     /**
-     * Gets the user's ID.
-     *
-     * @return string The user's ID.
+     * @var ApiClient|null
      */
-    public function getId()
+    protected $client;
+
+    /**
+     * @var array
+     */
+    protected $data;
+
+    /**
+     * User constructor.
+     * @param ApiClient|null $client
+     * @param array $data
+     */
+    public function __construct(ApiClient $client = null, array $data = [])
     {
-        return $this->data['id'];
+        $this->client = $client;
+        $this->data = $data;
     }
 
     /**
-     * Gets the user's username.
-     *
-     * Does not include the @ symbol at the beginning.
-     *
-     * @return string The user's username.
+     * @return null|ApiClient
      */
-    public function getUsername()
+    public function getClient()
     {
-        return $this->data['name'];
+        return $this->client;
     }
 
     /**
-     * Gets the user's first name if supplied.
-     *
-     * @return string The user's first name, or null if no name was given.
+     * @return array
      */
-    public function getFirstName()
+    public function getRawUser()
     {
-        return isset($this->data['profile']['first_name']) ? $this->data['profile']['first_name'] : null;
-    }
-
-    /**
-     * Gets the user's last name if supplied.
-     *
-     * @return string The user's last name, or null if no name was given.
-     */
-    public function getLastName()
-    {
-        return isset($this->data['profile']['last_name']) ? $this->data['profile']['last_name'] : null;
-    }
-
-    /**
-     * Gets the user's real name if supplied.
-     *
-     * @return string The user's real name, or null if no name was given.
-     */
-    public function getRealName()
-    {
-        return isset($this->data['profile']['real_name']) ? $this->data['profile']['real_name'] : null;
-    }
-
-    /**
-     * Gets the user's email address if supplied.
-     *
-     * @return string The user's email address, or null if no email was given.
-     */
-    public function getEmail()
-    {
-        return isset($this->data['profile']['email']) ? $this->data['profile']['email'] : null;
-    }
-
-    /**
-     * Gets the user's phone number if supplied.
-     *
-     * @return string The user's phone number, or null if no number was given.
-     */
-    public function getPhone()
-    {
-        return isset($this->data['profile']['phone']) ? $this->data['profile']['phone'] : null;
-    }
-
-    /**
-     * Gets the user's Skype name if supplied.
-     *
-     * @return string The user's Skype name, or null if no Skype name was given.
-     */
-    public function getSkype()
-    {
-        return isset($this->data['profile']['skype']) ? $this->data['profile']['skype'] : null;
-    }
-
-    /**
-     * Checks if the user is a team administrator.
-     *
-     * @return bool True if the user is a team administrator.
-     */
-    public function isAdmin()
-    {
-        return $this->data['is_admin'];
-    }
-
-    /**
-     * Checks if the user is a team owner.
-     *
-     * @return bool True if the user is a team owner.
-     */
-    public function isOwner()
-    {
-        return $this->data['is_owner'];
-    }
-
-    /**
-     * Checks if the user is the team's primary owner.
-     *
-     * @return bool True if the user is the primary team owner.
-     */
-    public function isPrimaryOwner()
-    {
-        return $this->data['is_primary_owner'];
-    }
-
-    /**
-     * Checks if the user has been deactivated.
-     *
-     * @return bool True if the user is deactivated.
-     */
-    public function isDeleted()
-    {
-        return $this->data['deleted'];
-    }
-
-    /**
-     * Gets a user's presence.
-     *
-     * @return \React\Promise\PromiseInterface The current user's presence, either "active" or "away".
-     */
-    public function getPresence()
-    {
-        return $this->client->apiCall('users.getPresence', [
-            'user' => $this->getId(),
-        ])->then(function (Payload $response) {
-            return $response['presence'];
-        });
-    }
-
-    /**
-     * User profile image URL 24x24px
-     *
-     * @return string URL of the 24x24px user profile image
-     */
-    public function getProfileImage24()
-    {
-        return $this->data['profile']['image_24'];
-    }
-
-    /**
-     * User profile image URL 32x32px
-     *
-     * @return string URL of the 32x32px user profile image
-     */
-    public function getProfileImage32()
-    {
-        return $this->data['profile']['image_32'];
-    }
-
-    /**
-     * User profile image URL 48x48px
-     *
-     * @return string URL of the 48x48px user profile image
-     */
-    public function getProfileImage48()
-    {
-        return $this->data['profile']['image_48'];
-    }
-
-    /**
-     * User profile image URL 72x72px
-     *
-     * @return string URL of the 72x72px user profile image
-     */
-    public function getProfileImage72()
-    {
-        return $this->data['profile']['image_72'];
-    }
-
-    /**
-     * User profile image URL 192x192px
-     *
-     * @return string URL of the 192x192px user profile image
-     */
-    public function getProfileImage192()
-    {
-        return $this->data['profile']['image_192'];
+        return $this->data;
     }
 }

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -93,12 +93,12 @@ class ChannelTest extends TestCase
         $this->mockResponse(200, null, [
             'ok' => true,
             'user' => [
-                'id' => $creator->data['id'],
+                'id' => $creator->getId(),
             ],
         ]);
 
         $this->watchPromise($channel->getCreator()->then(function (User $user) use ($creator) {
-            $this->assertEquals($creator->data, $user->data);
+            $this->assertEquals($creator->getRawUser(), $user->getRawUser());
         }));
     }
 }

--- a/tests/Message/MessageBuilderTest.php
+++ b/tests/Message/MessageBuilderTest.php
@@ -53,7 +53,7 @@ class MessageBuilderTest extends TestCase
 
         $this->mockResponse(200, null, [
             'ok' => true,
-            'user' => $user->data,
+            'user' => $user->getRawUser(),
         ]);
 
         $this->watchPromise($message->getUser()->then(function (User $user) {

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -144,4 +144,139 @@ class UserTest extends TestCase
             $this->assertEquals($presence, $actual);
         }));
     }
+
+    public function testId()
+    {
+        $id = $this->faker->word;
+
+        $user = new User($this->client, [
+            'id' => $id,
+        ]);
+
+        $this->assertEquals($id, $user->getId());
+    }
+
+    public function testIsDeleted()
+    {
+        $is = $this->faker->boolean;
+
+        $user = new User($this->client, [
+            'deleted' => $is,
+        ]);
+
+        $this->assertEquals($is, $user->isDeleted());
+    }
+
+    public function testProfileImage24()
+    {
+        $image = $this->faker->imageUrl(24, 24);
+
+        $user = new User($this->client, [
+            'profile' => [
+                'image_24' => $image,
+            ],
+        ]);
+
+        $this->assertEquals($image, $user->getProfileImage24());
+    }
+
+    public function testProfileImage32()
+    {
+        $image = $this->faker->imageUrl(32, 32);
+
+        $user = new User($this->client, [
+            'profile' => [
+                'image_32' => $image,
+            ],
+        ]);
+
+        $this->assertEquals($image, $user->getProfileImage32());
+    }
+
+    public function testProfileImage48()
+    {
+        $image = $this->faker->imageUrl(48, 48);
+
+        $user = new User($this->client, [
+            'profile' => [
+                'image_48' => $image,
+            ],
+        ]);
+
+        $this->assertEquals($image, $user->getProfileImage48());
+    }
+
+    public function testProfileImage72()
+    {
+        $image = $this->faker->imageUrl(72, 72);
+
+        $user = new User($this->client, [
+            'profile' => [
+                'image_72' => $image,
+            ],
+        ]);
+
+        $this->assertEquals($image, $user->getProfileImage72());
+    }
+
+    public function testProfileImage192()
+    {
+        $image = $this->faker->imageUrl(192, 192);
+
+        $user = new User($this->client, [
+            'profile' => [
+                'image_192' => $image,
+            ],
+        ]);
+
+        $this->assertEquals($image, $user->getProfileImage192());
+    }
+
+    public function testStatusText()
+    {
+        $status = $this->faker->words();
+
+        $user = new User($this->client, [
+            'profile' => [
+                'status_text' => $status,
+            ],
+        ]);
+
+        $this->assertEquals($status, $user->getStatusText());
+    }
+
+    public function testStatusEmoji()
+    {
+        $emoji = ':' . $this->faker->word . ':';
+
+        $user = new User($this->client, [
+            'profile' => [
+                'status_emoji' => $emoji,
+            ],
+        ]);
+
+        $this->assertEquals($emoji, $user->getStatusEmoji());
+    }
+
+    public function testColor()
+    {
+        $color = str_replace('#', '', $this->faker->hexColor);
+
+        $user = new User($this->client, [
+            'color' => $color,
+        ]);
+
+        $this->assertEquals($color, $user->getColor());
+    }
+
+    public function testUpdated()
+    {
+        $timestamp = time();
+
+        $user = new User($this->client, [
+            'updated' => $timestamp,
+        ]);
+
+        $this->assertEquals($timestamp, $user->getUpdated());
+    }
 }


### PR DESCRIPTION
Allow the User object to store more properties, and being easily callable from the drivers.

I'm not even sure if this is a BC Break because the previous User class was extending ClientObject and the new has exactly the same constructor/methods, maybe we should do a ClientObject interface? @mpociot 


Note that if this PR get merged I can directly submit the patch for the slack-driver.