### PR TITLE
Forward compatibility with react/event-loop 1.0 and 0.5 while still supporting 0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "mpociot/phpws": "^2.0",
         "evenement/evenement": "~3.0",
         "guzzlehttp/guzzle": "~6.0",
-        "react/event-loop": "^0.4.1",
+        "react/event-loop": "^1.0 || ^0.5 || ^0.4",
         "react/promise": "^2.2"
     },
     "require-dev": {

--- a/src/RealTimeClient.php
+++ b/src/RealTimeClient.php
@@ -352,11 +352,10 @@ class RealTimeClient extends ApiClient
      * Set as typing
      *
      * @param \Slack\ChannelInterface $channel The channel to set typing indicator in.
-     * @param bool $callDeferred Whether to call the API asynchronous or not.
      *
      * @return \React\Promise\PromiseInterface
      */
-    public function setAsTyping(ChannelInterface $channel, $callDeferred = true)
+    public function setAsTyping(ChannelInterface $channel)
     {
         if (!$this->connected) {
             return Promise\reject(new ConnectionException('Client not connected. Did you forget to call `connect()`?'));
@@ -368,12 +367,6 @@ class RealTimeClient extends ApiClient
             'channel' => $channel->data['id'],
         ];
         $this->websocket->send(json_encode($data));
-
-        // Perform an iteration of the event loop in order to send the
-        // web socket message synchronously
-        if (!$callDeferred) {
-            $this->loop->tick();
-        }
 
         return Promise\resolve();
     }


### PR DESCRIPTION
When upgrading my logging microservice I came across that this package hasn't been updated to event loop 0.5. Here by my PR that upgrades it and still support the current version.

There is one thing though, I've removed a call to `LoopInterface::tick()` because it has been removed in event loop 0.5 and I couldn't figure out a good way replace it with something else. Mainly because a single `tick()` call doesn't guarantee the desired operation to fulfill completely.