### PR TITLE
Missing slash for GuzzleHttp\ClientInterface

### DIFF
--- a/src/RealTimeClient.php
+++ b/src/RealTimeClient.php
@@ -75,7 +75,7 @@ class RealTimeClient extends ApiClient
     /**
      * {@inheritDoc}
      */
-    public function __construct(LoopInterface $loop, GuzzleHttp\ClientInterface $httpClient = null)
+    public function __construct(LoopInterface $loop, \GuzzleHttp\ClientInterface $httpClient = null)
     {
         parent::__construct($loop, $httpClient);
 


### PR DESCRIPTION
This fixes a direct issue for me, introduced in [`1.2.0`](https://github.com/mpociot/slack-client/compare/1.1...master#diff-e6c46e638201e6b988282bf7efb4cc00R78) that prevents me from injecting my own guzzle instance.